### PR TITLE
AbuseIPDBClient lacks support of "CheckBlock" which checks an entire IP Block

### DIFF
--- a/src/Kenc.AbuseIPDB.Tests/AbuseIpDbClientTests.cs
+++ b/src/Kenc.AbuseIPDB.Tests/AbuseIpDbClientTests.cs
@@ -1,0 +1,88 @@
+﻿namespace Kenc.AbuseIPDB.Tests
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Kenc.AbuseIPDB.Entities;
+    using Kenc.AbuseIPDB.Exceptions;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using Moq.Protected;
+
+    [TestClass]
+    public class AbuseIpDbClientTests
+    {
+        [TestMethod]
+        public async Task ReadsRateLimitHeader()
+        {
+            using var content = new StringContent("{}");
+            using var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = content,
+            };
+
+            response.Headers.Add("X-RateLimit-Limit", "1000");
+            response.Headers.Add("X-RateLimit-Remaining", "100");
+            response.Headers.Add("X-RateLimit-Reset", "1545973200");
+
+            var httpMessageHandler = new Mock<HttpMessageHandler>();
+            httpMessageHandler
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(response);
+
+            var httpClient = new HttpClient(httpMessageHandler.Object);
+            var abuseIpDbClient = new AbuseIPDBClient(httpClient, "apiKey", new Uri("https://api.abuseipdb.com/api/v2/"));
+            (CheckBlockData data, RateLimit rateLimit) = await abuseIpDbClient.CheckBlockAsync("127.0.0.1/24", 30, CancellationToken.None);
+
+            rateLimit.Limit.Should().Be(1000);
+            rateLimit.Remaining.Should().Be(100);
+            rateLimit.Reset.Should().Be(new DateTimeOffset(2018, 12, 28, 5, 0, 0, TimeSpan.Zero));
+        }
+
+        [TestMethod]
+        public async Task ReadsErrorResponse()
+        {
+            using var content = new StringContent(@"{
+  ""errors"": [
+      {
+          ""detail"": ""Daily rate limit of 1000 requests exceeded for this endpoint. See headers for additional details."",
+          ""status"": 429
+      }
+  ]
+}");
+
+            using var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.TooManyRequests,
+                Content = content,
+            };
+
+            var httpMessageHandler = new Mock<HttpMessageHandler>();
+            httpMessageHandler
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(response);
+
+            var httpClient = new HttpClient(httpMessageHandler.Object);
+            var abuseIpDbClient = new AbuseIPDBClient(httpClient, "apiKey", new Uri("https://api.abuseipdb.com/api/v2/"));
+
+            async Task action() => await abuseIpDbClient.CheckBlockAsync("127.0.0.1/24", 30, CancellationToken.None);
+            ApiException exception = await Assert.ThrowsExceptionAsync<ApiException>(action);
+
+            ApiReplies.Error firstError = exception.Errors[0];
+            firstError.Status.Should().Be(HttpStatusCode.TooManyRequests);
+            firstError.Detail.Should().Be("Daily rate limit of 1000 requests exceeded for this endpoint. See headers for additional details.");
+        }
+    }
+}

--- a/src/Kenc.AbuseIPDB.Tests/CheckBlockTests.cs
+++ b/src/Kenc.AbuseIPDB.Tests/CheckBlockTests.cs
@@ -1,0 +1,90 @@
+﻿namespace Kenc.AbuseIPDB.Tests
+{
+    using System;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Kenc.AbuseIPDB.Entities;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using Moq.Protected;
+
+    [TestClass]
+    public class CheckBlockTests
+    {
+        [TestMethod]
+        public async Task ResponseIsDeserializedAsExpected()
+        {
+            using var content = new StringContent(@"{
+    ""data"": {
+      ""networkAddress"": ""127.0.0.0"",
+      ""netmask"": ""255.255.255.0"",
+      ""minAddress"": ""127.0.0.1"",
+      ""maxAddress"": ""127.0.0.254"",
+      ""numPossibleHosts"": 254,
+      ""addressSpaceDesc"": ""Loopback"",
+      ""reportedAddress"": [
+        {
+          ""ipAddress"": ""127.0.0.1"",
+          ""numReports"": 631,
+          ""mostRecentReport"": ""2019-03-21T16:35:16+00:00"",
+          ""abuseConfidenceScore"": 0,
+          ""countryCode"": null
+        },
+        {
+          ""ipAddress"": ""127.0.0.2"",
+          ""numReports"": 16,
+          ""mostRecentReport"": ""2019-03-12T20:31:17+00:00"",
+          ""abuseConfidenceScore"": 0,
+          ""countryCode"": null
+        },
+        {
+          ""ipAddress"": ""127.0.0.3"",
+          ""numReports"": 17,
+          ""mostRecentReport"": ""2019-03-12T20:31:44+00:00"",
+          ""abuseConfidenceScore"": 0,
+          ""countryCode"": null
+        }
+      ]
+    }
+}");
+            using var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = content,
+            };
+
+            var httpMessageHandler = new Mock<HttpMessageHandler>();
+            httpMessageHandler
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(response);
+
+            var httpClient = new HttpClient(httpMessageHandler.Object);
+            var abuseIpDbClient = new AbuseIPDBClient(httpClient, "apiKey", new Uri("https://api.abuseipdb.com/api/v2/"));
+            (CheckBlockData data, RateLimit rateLimit) = await abuseIpDbClient.CheckBlockAsync("127.0.0.1/24", 30, CancellationToken.None);
+
+            // check the result
+            data.NetworkAddress.Should().Be("127.0.0.0");
+            data.Netmask.Should().Be("255.255.255.0");
+            data.MinAddress.Should().Be("127.0.0.1");
+            data.MaxAddress.Should().Be("127.0.0.254");
+            data.NumPossibleHosts.Should().Be(254);
+            data.AddressSpaceDesc.Should().Be("Loopback");
+            data.ReportedAddress.Count.Should().Be(3);
+
+            CheckBlockEntry[] reportedAddresses = data.ReportedAddress.ToArray();
+            reportedAddresses[0].IPAddress.Should().Be("127.0.0.1");
+            reportedAddresses[0].NumReports.Should().Be(631);
+            reportedAddresses[0].MostRecentReport.Should().Be(new DateTimeOffset(2019, 03, 21, 16, 35, 16, 0, TimeSpan.Zero));
+            reportedAddresses[0].AbuseConfidenceScore.Should().Be(0);
+            reportedAddresses[0].CountryCode.Should().BeNull();
+        }
+    }
+}

--- a/src/Kenc.AbuseIPDB.Tests/IntegrationTests.cs
+++ b/src/Kenc.AbuseIPDB.Tests/IntegrationTests.cs
@@ -30,10 +30,10 @@
         [TestMethod]
         public async Task HandleErrorsCorrectly()
         {
-            static async Task fdas() =>
+            static async Task action() =>
                 await client.ReportAsync("127.0.0.2", "Validation testing report endpoint", new[] { Category.BadWebBot });
 
-            ApiException exception = await Assert.ThrowsExceptionAsync<ApiException>(fdas);
+            ApiException exception = await Assert.ThrowsExceptionAsync<ApiException>(action);
 
             ApiReplies.Error firstError = exception.Errors[0];
             firstError.Status.Should().Be(HttpStatusCode.Forbidden);
@@ -49,6 +49,18 @@
 
             data.IpAddress.Should().Be(ip);
             data.CountryCode.Should().Be("US");
+        }
+
+        [TestMethod]
+        public async Task DoCheckBlock()
+        {
+            (Entities.CheckBlockData data, RateLimit _) = await client.CheckBlockAsync("127.0.0.1/24");
+            data.NetworkAddress.Should().Be("127.0.0.1");
+            data.Netmask.Should().Be("255.255.255.0");
+            data.MinAddress.Should().Be("127.0.0.1");
+            data.MaxAddress.Should().Be("127.0.0.254");
+            data.NumPossibleHosts.Should().Be(254);
+            data.AddressSpaceDesc.Should().Be("Loopback");
         }
     }
 }

--- a/src/Kenc.AbuseIPDB.Tests/Kenc.AbuseIPDB.Tests.csproj
+++ b/src/Kenc.AbuseIPDB.Tests/Kenc.AbuseIPDB.Tests.csproj
@@ -6,10 +6,14 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kenc.AbuseIPDB/AbuseIPDBClient.cs
+++ b/src/Kenc.AbuseIPDB/AbuseIPDBClient.cs
@@ -22,7 +22,7 @@
     {
         private readonly Uri baseUri;
         private readonly HttpClient httpClient;
-        private static readonly JsonSerializerOptions jsonSerializerOptions = new JsonSerializerOptions
+        private static readonly JsonSerializerOptions jsonSerializerOptions = new()
         {
             IgnoreNullValues = true
         };
@@ -78,6 +78,14 @@
             HttpResponseMessage httpResponseMessage = await httpClient.PostAsync(targetUri, null, cancellationToken);
 
             return await HandleSingleResultAsync<ReportUpdate>(httpResponseMessage, cancellationToken);
+        }
+
+        public async Task<(CheckBlockData data, RateLimit rateLimit)> CheckBlockAsync(string ipBlock, int maxAgeInDays = 30, CancellationToken cancellationToken = default)
+        {
+            var targetUri = new Uri(baseUri, $"check-block?network={HttpUtility.UrlEncode(ipBlock)}&maxAgeInDays={maxAgeInDays}");
+            HttpResponseMessage httpResponseMessage = await httpClient.GetAsync(targetUri, cancellationToken);
+
+            return await HandleSingleResultAsync<CheckBlockData>(httpResponseMessage, cancellationToken);
         }
 
         private async Task<(T Data, RateLimit RateLimit)> HandleResultAsync<T>(HttpResponseMessage httpResponseMessage, CancellationToken cancellationToken) where T : IApiReply

--- a/src/Kenc.AbuseIPDB/ApiReplies/Error.cs
+++ b/src/Kenc.AbuseIPDB/ApiReplies/Error.cs
@@ -3,14 +3,26 @@
     using System.Net;
     using System.Text.Json.Serialization;
 
+    /// <summary>
+    /// Class wrapping an error in the AbuseIPDB API.
+    /// </summary>
     public class Error
     {
+        /// <summary>
+        /// Gets or sets the detail parameter.
+        /// </summary>
         [JsonPropertyName("detail")]
         public string Detail { get; set; }
 
+        /// <summary>
+        /// Gets or sets the status code parameter.
+        /// </summary>
         [JsonPropertyName("status")]
         public HttpStatusCode Status { get; set; }
 
+        /// <summary>
+        /// Gets or sets the source parameter.
+        /// </summary>
         [JsonPropertyName("source")]
         public ErrorSource Source { get; set; }
     }

--- a/src/Kenc.AbuseIPDB/Entities/CheckBlockData.cs
+++ b/src/Kenc.AbuseIPDB/Entities/CheckBlockData.cs
@@ -1,0 +1,30 @@
+﻿namespace Kenc.AbuseIPDB.Entities
+{
+    using System.Collections.Generic;
+    using System.Text.Json.Serialization;
+    using Kenc.AbuseIPDB.ApiReplies;
+
+    public class CheckBlockData : IApiEntity
+    {
+        [JsonPropertyName("networkAddress")]
+        public string NetworkAddress { get; set; }
+
+        [JsonPropertyName("netmask")]
+        public string Netmask { get; set; }
+
+        [JsonPropertyName("minAddress")]
+        public string MinAddress { get; set; }
+
+        [JsonPropertyName("maxAddress")]
+        public string MaxAddress { get; set; }
+
+        [JsonPropertyName("numPossibleHosts")]
+        public int NumPossibleHosts { get; set; }
+
+        [JsonPropertyName("addressSpaceDesc")]
+        public string AddressSpaceDesc { get; set; }
+
+        [JsonPropertyName("reportedAddress")]
+        public IReadOnlyList<CheckBlockEntry> ReportedAddress { get; set; }
+    }
+}

--- a/src/Kenc.AbuseIPDB/Entities/CheckBlockEntry.cs
+++ b/src/Kenc.AbuseIPDB/Entities/CheckBlockEntry.cs
@@ -1,0 +1,23 @@
+﻿namespace Kenc.AbuseIPDB.Entities
+{
+    using System;
+    using System.Text.Json.Serialization;
+
+    public class CheckBlockEntry
+    {
+        [JsonPropertyName("ipAddress")]
+        public string IPAddress { get; set; }
+
+        [JsonPropertyName("numReports")]
+        public int NumReports { get; set; }
+
+        [JsonPropertyName("mostRecentReport")]
+        public DateTimeOffset MostRecentReport { get; set; }
+
+        [JsonPropertyName("abuseConfidenceScore")]
+        public int AbuseConfidenceScore { get; set; }
+
+        [JsonPropertyName("countryCode")]
+        public string CountryCode { get; set; }
+    }
+}

--- a/src/Kenc.AbuseIPDB/Exceptions/ApiException.cs
+++ b/src/Kenc.AbuseIPDB/Exceptions/ApiException.cs
@@ -4,13 +4,25 @@
     using System.Net;
     using Kenc.AbuseIPDB.ApiReplies;
 
+    /// <summary>
+    /// Exception class wrapping errors returned from AbuseIPDB API.
+    /// </summary>
     public class ApiException : Exception
     {
-        public HttpStatusCode StatusCode { get; set; }
+        /// <summary>
+        /// Gets the status code returned in the HTTP response.
+        /// </summary>
+        public HttpStatusCode StatusCode { get; private set; }
 
-        public Error[] Errors { get; set; }
+        /// <summary>
+        /// Gets the errors returned in the response body.
+        /// </summary>
+        public Error[] Errors { get; private set; }
 
-        public RateLimit RateLimit { get; set; }
+        /// <summary>
+        /// Gets the rate limit header.
+        /// </summary>
+        public RateLimit RateLimit { get; private set; }
 
         public ApiException(HttpStatusCode statusCode, Error[] errors, RateLimit rateLimit) : base($"AbuseIPDB returned errors. See {nameof(Errors)} for details.")
         {

--- a/src/Kenc.AbuseIPDB/Extensions/DependencyInjection.cs
+++ b/src/Kenc.AbuseIPDB/Extensions/DependencyInjection.cs
@@ -5,6 +5,12 @@
 
     public static class DependencyInjection
     {
+        /// <summary>
+        /// Add <see cref="IAbuseIPDBClient"/> to dependency injection.
+        /// </summary>
+        /// <param name="serviceCollection">Service collection to add it to</param>
+        /// <param name="configuration">Configuration to parse <see cref="AbuseIPDBClientSettings"/> from.</param>
+        /// <returns>The service collection.</returns>
         public static IServiceCollection AddAbuseIPDBClient(this IServiceCollection serviceCollection, IConfiguration configuration)
         {
             return serviceCollection.AddSingleton<IAbuseIPDBClient, AbuseIPDBClient>()

--- a/src/Kenc.AbuseIPDB/IAbuseIPDBClient.cs
+++ b/src/Kenc.AbuseIPDB/IAbuseIPDBClient.cs
@@ -32,7 +32,19 @@
         /// <param name="categories">Categories of the report.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns></returns>
-        /// <remarks> STRIP ANY PERSONALLY IDENTIFIABLE INFORMATION (PPI); AbuseIPDB IS NOT RESPONSIBLE FOR PPI YOU REVEAL.</remarks>
+        /// <remarks>STRIP ANY PERSONALLY IDENTIFIABLE INFORMATION (PPI); AbuseIPDB IS NOT RESPONSIBLE FOR PII YOU REVEAL.</remarks>
         Task<(ReportUpdate Data, RateLimit rateLimit)> ReportAsync(string ip, string comment, Category[] categories, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// The check-block endpoint accepts a subnet (v4 or v6) denoted with CIDR notation.
+        /// The maxAgeInDays parameter determines how old the reports considered in the query search can be.
+        /// The desired data is stored in the data property.Here you can inspect details regarding the network queried, such as the netmask of the subnet, the number of hosts it can possibly contain, and the assigned description of the address space.
+        /// The network should be url-encoded, because the network parameter contains a forward slash, which is a reserved character in URIs.
+        /// </summary>
+        /// <param name="ipBlock">CIDR notation of either an IPv4 or IPv6 subnet.</param>
+        /// <param name="maxAgeInDays">Max number of days.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns></returns>
+        Task<(CheckBlockData data, RateLimit rateLimit)> CheckBlockAsync(string ipBlock, int maxAgeInDays = 30, CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
- Adds support for "CheckBlock" endpoint, #3  
- Adding comments to various classes
- Upgrading packages in the test project