### PR TITLE
Add cached client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,113 @@
 # kenc.abuseipdb
-Wrapper around abuseipdb.com API
+Wrapper around abuseipdb.com API for .net
+
+## Getting started
+
+```Powershell
+PM> Install-Package Kenc.AbuseIPDB
+```
+
+Kenc.AbuseIPDb is built with dependency-injection as a first-class-citizen.
+As a result, there's a helper function to register the library including pointing to the configuration section, if IConfiguration is being utilized.
+
+```C#
+services.AddAbuseIPDBClient(Configuration.GetSection("AbuseIPDB"));
+```
+
+with the configuration section "AbuseIPDB" having the following settings:
+```JSON
+  "AbuseIPDB": {
+    "APIKey": "<APIKey>",
+    "APIEndpoint": "https://api.abuseipdb.com/api/v2/"
+  }
+```
+
+_Note_: Don't embed your API key with your source code, load it from [keyvault](https://docs.microsoft.com/en-us/aspnet/core/security/key-vault-configuration?view=aspnetcore-5.0) or another secure storage.
+
+### Using the client
+With the client registered with dependency injection, add IAbuseIPDBClient abuseIPDBClient to your constructor, eg:
+```C#
+private readonly ILogger<HomeController> _logger;
+private readonly IAbuseIPDBClient _abuseIPDBClient;
+private readonly IHttpContextAccessor _httpContextAccessor;
+
+public HomeController(ILogger<HomeController> logger, IAbuseIPDBClient abuseIPDBClient, IHttpContextAccessor httpContextAccessor)
+{
+    _logger = logger;
+    _abuseIPDBClient = abuseIPDBClient ?? throw new ArgumentNullException(nameof(abuseIPDBClient));
+    _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+}
+```
+
+In an ASP.net MVC app, to check for an abusive IP:
+```C#
+[HttpPost]
+public async Task<IActionResult> PostComment(CommentModel comment)
+{
+    var ip = _httpContextAccessor.HttpContext.Features.Get<IHttpConnectionFeature>()?.RemoteIpAddress;
+    try
+    {
+        var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        (Check abuseCheck, _) = await _abuseIPDBClient.CheckAsync(ip.ToString(), 90, false, cancellationTokenSource.Token);
+
+        if (abuseCheck.AbuseConfidenceScore > 70)
+        {
+            _logger.LogWarning($"{nameof(HomeController)} refused comment by {ip} due to high abuse confidence score.");
+            var error = new ErrorModel
+            {
+                Title = "Bad Request.",
+                Detail = "User IP is blocked due to abuse.",
+                Instance = $"/comment/{Activity.Current?.Id ?? httpContextAccessor.HttpContext.TraceIdentifier}",
+                Status = 400,
+                Type = "/comment/abusiveip"
+            };
+
+            // return a 400 with the error information
+            return Unauthorized(error);
+        }
+    }
+    catch (OperationCanceledException)
+    {
+        _logger.LogError($"{nameof(HomeController)}: Failed to check AbuseIPDb within configured timeout.");
+    }
+    catch (ApiException abuseIPException)
+    {
+        _logger.LogError($"{nameof(HomeController)}: Caught error with AbuseIPDB: {abuseIPException.Message}");
+    }
+}
+```
+
+## Cached client
+
+In case you have a website with a significant amount of traffic, or where users are expected to send multiple requests, consider using the cached IAbuseIPDBClient. This adds a memory cache in-front, so only a single lookup per IP/block is made.
+
+```Powershell
+PM> Install-Package Kenc.AbuseIPDB
+```
+
+Register it with dependency injection using:
+
+```C#
+services.AddAbuseIPDBClientCache(Configuration.GetSection("AbuseIPDB"), Configuration.GetSection("AbuseIPDBCache"));
+```
+
+The configuration section can be used to configure for how long values are cached.
+
+| Name                    | Default  |
+| ----------------------- | -------- |
+| CheckCacheLifetime      | 1 hour   |
+| CheckBlockCacheLifetime | 1 hour   |
+| BlackListCacheLifetime  | 24 hours |
+
+Configuration values are deserialized into TimeSpan. By default these follow [ISO 8601 durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)
+
+The following sets the configurations to keep Check() responses for 1 minute, CheckBlock() responses for 2 hours and 30 minutes and lastly BlackList() checks for 36 hours.
+```json
+{
+    "AbuseIPDBCache": {
+        "CheckCacheLifetime": "PT1M",
+        "CheckBlockCacheLifetime": "PT2H30M",
+        "BlackListCacheLifetime": "PT36H"
+    }
+}
+```

--- a/src/Kenc.AbuseIPDB.Cache/CacheConfiguration.cs
+++ b/src/Kenc.AbuseIPDB.Cache/CacheConfiguration.cs
@@ -1,0 +1,25 @@
+﻿namespace Kenc.AbuseIPDB.Cache
+{
+    using System;
+
+    /// <summary>
+    /// Configuration of Abuse IP DB cache.
+    /// </summary>
+    public class CacheConfiguration
+    {
+        /// <summary>
+        /// Gets or sets how long to cache the results for Check operations.
+        /// </summary>
+        public TimeSpan CheckCacheLifetime { get; set; } = TimeSpan.FromMinutes(60);
+
+        /// <summary>
+        /// Gets or sets how long to cache the results for CheckBlock operations.
+        /// </summary>
+        public TimeSpan CheckBlockCacheLifetime { get; set; } = TimeSpan.FromMinutes(60);
+
+        /// <summary>
+        /// Gets or sets how long to cache the results for blacklists.
+        /// </summary>
+        public TimeSpan BlackListCacheLifetime { get; set; } = TimeSpan.FromHours(24);
+    }
+}

--- a/src/Kenc.AbuseIPDB.Cache/CachedAbuseIPDBClient.cs
+++ b/src/Kenc.AbuseIPDB.Cache/CachedAbuseIPDBClient.cs
@@ -1,0 +1,184 @@
+﻿namespace Kenc.AbuseIPDB.Cache
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Kenc.AbuseIPDB.Entities;
+    using Kenc.AbuseIPDB.Replies;
+    using LazyCache;
+    using Microsoft.Extensions.Options;
+
+    /// <summary>
+    /// Cache layer around <see cref="IAbuseIPDBClient"/>.
+    /// </summary>
+    /// <inheritdoc/>
+    public class CachedAbuseIPDBClient : IAbuseIPDBClient
+    {
+        private readonly IAppCache cache;
+        private readonly IAbuseIPDBClient client;
+        private readonly IOptions<CacheConfiguration> cacheConfiguration;
+        private readonly ReaderWriterLockSlim rwl = new();
+
+        private RateLimit latestCheckRateLimit;
+        private RateLimit latestBlackListRateLimit;
+        private RateLimit latestCheckBlockRateLimit;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CachedAbuseIPDBClient"/> class.
+        /// </summary>
+        /// <param name="client">Client to use for outgoing connections.</param>
+        /// <param name="cacheConfiguration">Configuration of the cache.</param>
+        /// <param name="cache">Instance of IAppCache.</param>
+        internal CachedAbuseIPDBClient(IAbuseIPDBClient client, IOptions<CacheConfiguration> cacheConfiguration, IAppCache cache = null)
+        {
+            this.client = client ?? throw new ArgumentNullException(nameof(client));
+            this.cache = cache ?? new CachingService();
+
+            if (cacheConfiguration.Value == null)
+            {
+                throw new ArgumentNullException(nameof(cacheConfiguration));
+            }
+
+            this.cacheConfiguration = cacheConfiguration;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CachedAbuseIPDBClient"/> class.
+        /// </summary>
+        /// <param name="httpClient">HTTPClient to use for connections.</param>
+        /// <param name="clientConfiguration">Configuration of <see cref="AbuseIPDBClient"/>.</param>
+        /// <param name="cacheConfiguration">Configuration of cache.</param>
+        /// <param name="cache">Instance of IAppCache.</param>
+        public CachedAbuseIPDBClient(HttpClient httpClient, IOptions<AbuseIPDBClientSettings> clientConfiguration, IOptions<CacheConfiguration> cacheConfiguration, IAppCache cache = null)
+        {
+            this.cache = cache ?? new CachingService();
+            if (cacheConfiguration.Value == null)
+            {
+                throw new ArgumentNullException(nameof(cacheConfiguration));
+            }
+
+            this.cacheConfiguration = cacheConfiguration;
+            client = new AbuseIPDBClient(httpClient, clientConfiguration);
+        }
+
+        public async Task<(IReadOnlyList<BlackListEntry> Data, BlackListMetadata Metadata, RateLimit RateLimit)> BlackListAsync(int confidenceMinimum = 100, int limit = 10000, CancellationToken cancellationToken = default)
+        {
+            (IReadOnlyList<BlackListEntry> data, BlackListMetadata metadata) = await cache.GetOrAddAsync($"blacklist_{confidenceMinimum}_{limit}", async (item) =>
+            {
+                item.AbsoluteExpirationRelativeToNow = cacheConfiguration.Value.BlackListCacheLifetime;
+                (IReadOnlyList<BlackListEntry> data, BlackListMetadata metadata, RateLimit rateLimit) = await client.BlackListAsync(confidenceMinimum, limit, cancellationToken);
+
+                if (rwl.TryEnterWriteLock(1000))
+                {
+                    try
+                    {
+                        latestBlackListRateLimit = rateLimit;
+                    }
+                    finally
+                    {
+                        rwl.ExitWriteLock();
+                    }
+                }
+
+                return (data, metadata);
+            });
+
+
+            if (rwl.TryEnterReadLock(1000))
+            {
+                try
+                {
+                    return (data, metadata, latestBlackListRateLimit);
+                }
+                finally
+                {
+                    rwl.ExitReadLock();
+                }
+            }
+
+            return (data, metadata, null);
+        }
+
+        public async Task<(Check Data, RateLimit RateLimit)> CheckAsync(string ipAddress, int maxAgeInDays, bool verbose, CancellationToken cancellationToken)
+        {
+            Check data = await cache.GetOrAddAsync(ipAddress, async (item) =>
+            {
+                item.AbsoluteExpirationRelativeToNow = cacheConfiguration.Value.CheckCacheLifetime;
+                (Check Data, RateLimit rateLimit) = await client.CheckAsync(ipAddress, maxAgeInDays, verbose, cancellationToken);
+
+                if (rwl.TryEnterWriteLock(1000))
+                {
+                    try
+                    {
+                        latestCheckRateLimit = rateLimit;
+                    }
+                    finally
+                    {
+                        rwl.ExitWriteLock();
+                    }
+                }
+
+                return Data;
+            });
+
+
+            if (rwl.TryEnterReadLock(1000))
+            {
+                try
+                {
+                    return (data, latestCheckRateLimit);
+                }
+                finally
+                {
+                    rwl.ExitReadLock();
+                }
+            }
+
+            return (data, null);
+        }
+
+        public async Task<(CheckBlockData data, RateLimit rateLimit)> CheckBlockAsync(string ipBlock, int maxAgeInDays = 30, CancellationToken cancellationToken = default)
+        {
+            CheckBlockData data = await cache.GetOrAddAsync(ipBlock, async (item) =>
+            {
+                item.AbsoluteExpirationRelativeToNow = cacheConfiguration.Value.CheckBlockCacheLifetime;
+                (CheckBlockData Data, RateLimit rateLimit) = await client.CheckBlockAsync(ipBlock, maxAgeInDays, cancellationToken);
+
+                if (rwl.TryEnterWriteLock(1000))
+                {
+                    try
+                    {
+                        latestCheckBlockRateLimit = rateLimit;
+                    }
+                    finally
+                    {
+                        rwl.ExitWriteLock();
+                    }
+                }
+                return Data;
+            });
+
+
+            if (rwl.TryEnterReadLock(1000))
+            {
+                try
+                {
+                    return (data, latestCheckBlockRateLimit);
+                }
+                finally
+                {
+                    rwl.ExitReadLock();
+                }
+            }
+
+            return (data, null);
+        }
+
+        public Task<(ReportUpdate Data, RateLimit rateLimit)> ReportAsync(string ip, string comment, Category[] categories, CancellationToken cancellationToken = default)
+        {
+            return client.ReportAsync(ip, comment, categories, cancellationToken);
+        }
+    }
+}

--- a/src/Kenc.AbuseIPDB.Cache/Extensions/DependencyInjection.cs
+++ b/src/Kenc.AbuseIPDB.Cache/Extensions/DependencyInjection.cs
@@ -1,0 +1,22 @@
+﻿namespace Kenc.AbuseIPDB.Cache
+{
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+
+    public static class DependencyInjection
+    {
+        /// <summary>
+        /// Add <see cref="IAbuseIPDBClient"/> to dependency injection.
+        /// </summary>
+        /// <param name="serviceCollection">Service collection to add it to</param>
+        /// <param name="clientConfiguration">Configuration to parse <see cref="AbuseIPDBClientSettings"/> from.</param>
+        /// <param name="cacheConfiguration">Configuration to parse <see cref="CacheConfiguration"/> from.</param>
+        /// <returns>The service collection.</returns>
+        public static IServiceCollection AddAbuseIPDBClientCache(this IServiceCollection serviceCollection, IConfiguration clientConfiguration, IConfiguration cacheConfiguration)
+        {
+            return serviceCollection.AddSingleton<IAbuseIPDBClient, CachedAbuseIPDBClient>()
+                .Configure<AbuseIPDBClientSettings>(clientConfiguration)
+                .Configure<CacheConfiguration>(cacheConfiguration);
+        }
+    }
+}

--- a/src/Kenc.AbuseIPDB.Cache/Kenc.AbuseIPDB.Cache.csproj
+++ b/src/Kenc.AbuseIPDB.Cache/Kenc.AbuseIPDB.Cache.csproj
@@ -8,8 +8,8 @@
   <!-- nuget package properties -->
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageId>Kenc.AbuseIPDB</PackageId>
-    <PackageDescription>.net core standard library for interacting with the AbuseIPDB API v2.</PackageDescription>
+    <PackageId>Kenc.AbuseIPDB.Cache</PackageId>
+    <PackageDescription>Cache for Kenc.AbuseIPDB based on LazyCache.</PackageDescription>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/Kencdk/kenc.abuseipdb</PackageProjectUrl>
@@ -17,7 +17,7 @@
 
     <PackageTags>AbuseIPDB</PackageTags>
     <Copyright>2021 Ken Christensen</Copyright>
-    <Description>.net core standard library for interacting with the AbuseIPDB API v2.</Description>
+    <Description>Cache for Kenc.AbuseIPDB based on LazyCache.</Description>
 
     <!-- source link properties -->
     <RepositoryType>Github</RepositoryType>
@@ -29,15 +29,19 @@
 
   <ItemGroup>
     <PackageReference Include="LazyCache" Version="2.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
-    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Kenc.AbuseIPDB\Kenc.AbuseIPDB.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Kenc.AbuseIPDB.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/src/Kenc.AbuseIPDB.Tests/BlacklistTests.cs
+++ b/src/Kenc.AbuseIPDB.Tests/BlacklistTests.cs
@@ -1,0 +1,154 @@
+﻿namespace Kenc.AbuseIPDB.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Kenc.AbuseIPDB.Entities;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using Moq.Protected;
+
+    [TestClass]
+    public class BlacklistTests
+    {
+        private const string okBody = @"{
+  ""meta"": {
+    ""generatedAt"": ""2020-09-24T19:54:11+00:00""
+  },
+  ""data"": [
+    {
+      ""ipAddress"": ""5.188.10.179"",
+      ""abuseConfidenceScore"": 100,
+      ""lastReportedAt"": ""2020-09-24T19:17:02+00:00""
+    },
+    {
+      ""ipAddress"": ""185.222.209.14"",
+      ""abuseConfidenceScore"": 100,
+      ""lastReportedAt"": ""2020-09-24T19:17:02+00:00""
+    },
+    {
+      ""ipAddress"": ""191.96.249.183"",
+      ""abuseConfidenceScore"": 100,
+      ""lastReportedAt"": ""2020-09-24T19:17:01+00:00""
+    }
+  ]
+}";
+
+        [TestMethod]
+        public async Task BlacklistAddsParametersCorrectly()
+        {
+            using var content = new StringContent(okBody);
+            using var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = content,
+            };
+
+            HttpRequestMessage sentRequestMessage = null;
+
+            var httpMessageHandler = new Mock<HttpMessageHandler>();
+            httpMessageHandler
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>())
+               .Callback((HttpRequestMessage httpRequestMessage, CancellationToken cancellationToken) =>
+               {
+                   sentRequestMessage = httpRequestMessage;
+               })
+               .ReturnsAsync(response);
+
+            var httpClient = new HttpClient(httpMessageHandler.Object);
+            var abuseIpDbClient = new AbuseIPDBClient(httpClient, "apiKey", new Uri("https://api.abuseipdb.com/api/v2/"));
+            (IReadOnlyList<BlackListEntry> Data, Replies.BlackListMetadata Metadata, RateLimit RateLimit) = await abuseIpDbClient.BlackListAsync(90, 1000, CancellationToken.None);
+
+            sentRequestMessage.Should().NotBeNull();
+            sentRequestMessage.RequestUri.AbsoluteUri.Should().Be("https://api.abuseipdb.com/api/v2/blacklist?confidenceMinimum=90&limit=1000");
+        }
+
+        [TestMethod]
+        public async Task BlacklistAddsParametersWithDefaultValues()
+        {
+            using var content = new StringContent(okBody);
+            using var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = content,
+            };
+
+            HttpRequestMessage sentRequestMessage = null;
+
+            var httpMessageHandler = new Mock<HttpMessageHandler>();
+            httpMessageHandler
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>())
+               .Callback((HttpRequestMessage httpRequestMessage, CancellationToken cancellationToken) =>
+               {
+                   sentRequestMessage = httpRequestMessage;
+               })
+               .ReturnsAsync(response);
+
+            var httpClient = new HttpClient(httpMessageHandler.Object);
+            var abuseIpDbClient = new AbuseIPDBClient(httpClient, "apiKey", new Uri("https://api.abuseipdb.com/api/v2/"));
+            (IReadOnlyList<BlackListEntry> Data, Replies.BlackListMetadata Metadata, RateLimit RateLimit) = await abuseIpDbClient.BlackListAsync(cancellationToken: CancellationToken.None);
+
+            sentRequestMessage.Should().NotBeNull();
+            sentRequestMessage.RequestUri.AbsoluteUri.Should().Be("https://api.abuseipdb.com/api/v2/blacklist?confidenceMinimum=100&limit=10000");
+        }
+
+        [TestMethod]
+        public async Task ResponseIsDeserializedAsExpected()
+        {
+            using var content = new StringContent(okBody);
+            using var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = content,
+            };
+
+            var httpMessageHandler = new Mock<HttpMessageHandler>();
+            httpMessageHandler
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(response);
+
+            var httpClient = new HttpClient(httpMessageHandler.Object);
+            var abuseIpDbClient = new AbuseIPDBClient(httpClient, "apiKey", new Uri("https://api.abuseipdb.com/api/v2/"));
+            (IReadOnlyList<BlackListEntry> data, Replies.BlackListMetadata Metadata, RateLimit _) = await abuseIpDbClient.BlackListAsync(cancellationToken: CancellationToken.None);
+
+            Metadata.GeneratedAt.Should().Be(DateTimeOffset.Parse("2020-09-24T19:54:11+00:00"));
+
+            /*  ""meta"": {
+    ""generatedAt"": ""2020-09-24T19:54:11+00:00""
+  },
+  ""data"": [
+    {
+      ""ipAddress"": ""5.188.10.179"",
+      ""abuseConfidenceScore"": 100,
+      ""lastReportedAt"": ""2020-09-24T19:17:02+00:00""
+    },
+    {
+      ""ipAddress"": ""185.222.209.14"",
+      ""abuseConfidenceScore"": 100,
+      ""lastReportedAt"": ""2020-09-24T19:17:02+00:00""
+    },
+    {
+      ""ipAddress"": ""191.96.249.183"",
+      ""abuseConfidenceScore"": 100,
+      ""lastReportedAt"": ""2020-09-24T19:17:01+00:00""
+    }
+             * */
+        }
+    }
+}

--- a/src/Kenc.AbuseIPDB.Tests/CacheTests.cs
+++ b/src/Kenc.AbuseIPDB.Tests/CacheTests.cs
@@ -1,0 +1,137 @@
+﻿namespace Kenc.AbuseIPDB.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Kenc.AbuseIPDB.Entities;
+    using LazyCache;
+    using Microsoft.Extensions.Caching.Memory;
+    using Microsoft.Extensions.Options;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class CacheTests
+    {
+        [TestMethod]
+        public async Task SanityCheck()
+        {
+            var innerClient = new Mock<IAbuseIPDBClient>();
+            innerClient.Setup(x => x.CheckAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((new Check(), new RateLimit(0, 1000, 999, DateTimeOffset.UtcNow.AddHours(1))));
+
+            innerClient.Setup(x => x.CheckBlockAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((new CheckBlockData(), new RateLimit(0, 1000, 999, DateTimeOffset.UtcNow.AddHours(1))));
+
+            var configuration = new Cache.CacheConfiguration();
+            var instance = new Cache.CachedAbuseIPDBClient(innerClient.Object, Options.Create(configuration));
+
+            await instance.CheckAsync("127.0.0.1", 30, true, CancellationToken.None);
+            await instance.CheckBlockAsync("127.0.0.1/24", 30, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task CheckAsyncUsesRightCacheKey()
+        {
+            var innerClient = new Mock<IAbuseIPDBClient>();
+            innerClient.Setup(x => x.CheckAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((new Check(), new RateLimit(0, 1000, 999, DateTimeOffset.UtcNow.AddHours(1))));
+
+            var configuration = new Cache.CacheConfiguration();
+            var cache = new Mock<IAppCache>();
+            var instance = new Cache.CachedAbuseIPDBClient(innerClient.Object, Options.Create(configuration), cache.Object);
+
+            await instance.CheckAsync("127.0.0.1", 30, true, CancellationToken.None);
+
+            cache.Verify(x => x.GetOrAddAsync("127.0.0.1", It.IsAny<Func<ICacheEntry, Task<Check>>>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task CheckBlockAsyncUsesRightCacheKey()
+        {
+            var innerClient = new Mock<IAbuseIPDBClient>();
+            innerClient.Setup(x => x.CheckBlockAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((new CheckBlockData(), new RateLimit(0, 1000, 999, DateTimeOffset.UtcNow.AddHours(1))));
+
+            var configuration = new Cache.CacheConfiguration();
+            var cache = new Mock<IAppCache>();
+            var instance = new Cache.CachedAbuseIPDBClient(innerClient.Object, Options.Create(configuration), cache.Object);
+
+            await instance.CheckBlockAsync("127.0.0.1/24", 30, CancellationToken.None);
+
+            cache.Verify(x => x.GetOrAddAsync("127.0.0.1/24", It.IsAny<Func<ICacheEntry, Task<CheckBlockData>>>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task CheckAsyncCallsClientIfNotInCache()
+        {
+            var innerClient = new Mock<IAbuseIPDBClient>();
+            innerClient.Setup(x => x.CheckAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((new Check(), new RateLimit(0, 1000, 999, DateTimeOffset.UtcNow.AddHours(1))));
+
+            var cache = new LazyCache.Mocks.MockCachingService();
+
+            var configuration = new Cache.CacheConfiguration();
+            var instance = new Cache.CachedAbuseIPDBClient(innerClient.Object, Options.Create(configuration), cache);
+
+            await instance.CheckAsync("127.0.0.1", 30, true, CancellationToken.None);
+            innerClient.Verify(x => x.CheckAsync("127.0.0.1", 30, true, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task CheckBlockAsyncCallsClientIfNotInCache()
+        {
+            var innerClient = new Mock<IAbuseIPDBClient>();
+            innerClient.Setup(x => x.CheckBlockAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((new CheckBlockData(), new RateLimit(0, 1000, 999, DateTimeOffset.UtcNow.AddHours(1))));
+
+            var cache = new LazyCache.Mocks.MockCachingService();
+
+            var configuration = new Cache.CacheConfiguration();
+            var instance = new Cache.CachedAbuseIPDBClient(innerClient.Object, Options.Create(configuration), cache);
+
+            await instance.CheckBlockAsync("127.0.0.1/24", 30, CancellationToken.None);
+            innerClient.Verify(x => x.CheckBlockAsync("127.0.0.1/24", 30, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task ReportBypassesCache()
+        {
+            var innerClient = new Mock<IAbuseIPDBClient>();
+            innerClient.Setup(x => x.ReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Category[]>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((new ReportUpdate(), new RateLimit(0, 1000, 999, DateTimeOffset.UtcNow.AddHours(1))));
+
+            var cache = new Mock<IAppCache>();
+            var configuration = new Cache.CacheConfiguration();
+            var instance = new Cache.CachedAbuseIPDBClient(innerClient.Object, Options.Create(configuration), cache.Object);
+
+            await instance.ReportAsync("127.0.0.1", "Comment", new[] { Category.BadWebBot }, CancellationToken.None);
+            cache.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        public async Task BlackListUsesCache()
+        {
+            IReadOnlyList<BlackListEntry> blackList = new[]
+            {
+                new BlackListEntry()
+            }.ToList();
+
+            var innerClient = new Mock<IAbuseIPDBClient>();
+            innerClient.Setup(x => x.BlackListAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((blackList, new Replies.BlackListMetadata(), new RateLimit(0, 1000, 999, DateTimeOffset.UtcNow.AddHours(1))));
+
+            var cache = new CachingService();
+            var configuration = new Cache.CacheConfiguration();
+            var instance = new Cache.CachedAbuseIPDBClient(innerClient.Object, Options.Create(configuration), cache);
+
+            await instance.BlackListAsync();
+
+            (IReadOnlyList<BlackListEntry> data, Replies.BlackListMetadata metadata) = cache.Get<(IReadOnlyList<BlackListEntry> data, Replies.BlackListMetadata metadata)>("blacklist_100_10000");
+            data.Should().BeSameAs(blackList);
+        }
+    }
+}

--- a/src/Kenc.AbuseIPDB.Tests/CheckTests.cs
+++ b/src/Kenc.AbuseIPDB.Tests/CheckTests.cs
@@ -1,0 +1,135 @@
+﻿namespace Kenc.AbuseIPDB.Tests
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Kenc.AbuseIPDB.Entities;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using Moq.Protected;
+
+    [TestClass]
+    public class CheckTests
+    {
+        private const string okBody = @"{
+    ""data"": {
+      ""ipAddress"": ""118.25.6.39"",
+      ""isPublic"": true,
+      ""ipVersion"": 4,
+      ""isWhitelisted"": false,
+      ""abuseConfidenceScore"": 100,
+      ""countryCode"": ""CN"",
+      ""countryName"": ""China"",
+      ""usageType"": ""Data Center/Web Hosting/Transit"",
+      ""isp"": ""Tencent Cloud Computing (Beijing) Co. Ltd"",
+      ""domain"": ""tencent.com"",
+      ""hostnames"": [],
+      ""totalReports"": 1,
+      ""numDistinctUsers"": 1,
+      ""lastReportedAt"": ""2018-12-20T20:55:14+00:00"",
+      ""reports"": [
+        {
+          ""reportedAt"": ""2018-12-20T20:55:14+00:00"",
+          ""comment"": ""Dec 20 20:55:14 srv206 sshd[13937]: Invalid user oracle from 118.25.6.39"",
+          ""categories"": [
+            18,
+            22
+          ],
+          ""reporterId"": 1,
+          ""reporterCountryCode"": ""US"",
+          ""reporterCountryName"": ""United States""
+        }
+      ]
+    }
+}";
+
+        [DataTestMethod]
+        [DataRow(false, "https://api.abuseipdb.com/api/v2/check?ipAddress=127.0.0.1&maxAgeInDays=30")]
+        [DataRow(true, "https://api.abuseipdb.com/api/v2/check?ipAddress=127.0.0.1&maxAgeInDays=30&verbose")]
+        public async Task CheckAddsParametersCorrectly(bool verbose, string expectedUrl)
+        {
+            using var content = new StringContent(okBody);
+            using var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = content,
+            };
+
+            HttpRequestMessage sentRequestMessage = null;
+
+            var httpMessageHandler = new Mock<HttpMessageHandler>();
+            httpMessageHandler
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>())
+               .Callback((HttpRequestMessage httpRequestMessage, CancellationToken cancellationToken) =>
+               {
+                   sentRequestMessage = httpRequestMessage;
+               })
+               .ReturnsAsync(response);
+
+            var httpClient = new HttpClient(httpMessageHandler.Object);
+            var abuseIpDbClient = new AbuseIPDBClient(httpClient, "apiKey", new Uri("https://api.abuseipdb.com/api/v2/"));
+            (Check data, RateLimit rateLimit) = await abuseIpDbClient.CheckAsync("127.0.0.1", 30, verbose, CancellationToken.None);
+
+            sentRequestMessage.Should().NotBeNull();
+            sentRequestMessage.RequestUri.AbsoluteUri.Should().Be(expectedUrl);
+        }
+
+        [TestMethod]
+        public async Task ResponseIsDeserializedAsExpected()
+        {
+            using var content = new StringContent(okBody);
+            using var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = content,
+            };
+
+            var httpMessageHandler = new Mock<HttpMessageHandler>();
+            httpMessageHandler
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(response);
+
+            var httpClient = new HttpClient(httpMessageHandler.Object);
+            var abuseIpDbClient = new AbuseIPDBClient(httpClient, "apiKey", new Uri("https://api.abuseipdb.com/api/v2/"));
+            (Check data, RateLimit rateLimit) = await abuseIpDbClient.CheckAsync("118.25.6.39", 30, true, CancellationToken.None);
+
+            // check the result
+            data.IpAddress.Should().Be("118.25.6.39");
+            data.IsPublic.Should().BeTrue();
+            data.IPVersion.Should().Be(4);
+            data.IsWhitelisted.Should().BeFalse();
+            data.AbuseConfidenceScore.Should().Be(100);
+            data.CountryCode.Should().Be("CN");
+            data.CountryName.Should().Be("China");
+            data.UsageType.Should().Be("Data Center/Web Hosting/Transit");
+            data.ISP.Should().Be("Tencent Cloud Computing (Beijing) Co. Ltd");
+            data.Domain.Should().Be("tencent.com");
+            data.Hostnames.Should().BeEmpty();
+            data.TotalReports.Should().Be(1);
+            data.NumberOfDistinctUsers.Should().Be(1);
+            data.LastReportedAt.Should().Be(DateTimeOffset.Parse("2018-12-20T20:55:14+00:00"));
+            data.Reports.Should().HaveCount(1);
+
+            Report report = data.Reports[0];
+            report.Should().NotBeNull();
+            report.ReportedAt.Should().Be(DateTimeOffset.Parse("2018-12-20T20:55:14+00:00"));
+            report.Comment.Should().Be("Dec 20 20:55:14 srv206 sshd[13937]: Invalid user oracle from 118.25.6.39");
+            report.Categories.Should().HaveCount(2);
+            report.Categories.Should().BeEquivalentTo(new[] { Category.BruteForce, Category.SSH });
+            report.ReporterId.Should().Be(1);
+            report.ReporterCountryCode.Should().Be("US");
+            report.ReporterCountryName.Should().Be("United States");
+        }
+    }
+}

--- a/src/Kenc.AbuseIPDB.Tests/IntegrationTests.cs
+++ b/src/Kenc.AbuseIPDB.Tests/IntegrationTests.cs
@@ -11,6 +11,7 @@
 
     [TestClass]
     [TestCategory(TestConstants.IntegrationTests)]
+    [TestCategory("SkipWhenLiveUnitTesting")]
     public class IntegrationTests
     {
         private static IAbuseIPDBClient client;

--- a/src/Kenc.AbuseIPDB.Tests/Kenc.AbuseIPDB.Tests.csproj
+++ b/src/Kenc.AbuseIPDB.Tests/Kenc.AbuseIPDB.Tests.csproj
@@ -6,17 +6,15 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.4" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Kenc.AbuseIPDB.Cache\Kenc.AbuseIPDB.Cache.csproj" />
     <ProjectReference Include="..\Kenc.AbuseIPDB\Kenc.AbuseIPDB.csproj" />
   </ItemGroup>
 

--- a/src/Kenc.AbuseIPDB.Tests/ReportTests.cs
+++ b/src/Kenc.AbuseIPDB.Tests/ReportTests.cs
@@ -1,0 +1,85 @@
+﻿namespace Kenc.AbuseIPDB.Tests
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Kenc.AbuseIPDB.Entities;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using Moq.Protected;
+
+    [TestClass]
+    public class ReportTests
+    {
+        private const string okBody = @"{
+    ""data"": {
+      ""ipAddress"": ""127.0.0.1"",
+      ""abuseConfidenceScore"": 52
+    }
+}";
+
+        [TestMethod]
+        public async Task CheckAddsParametersCorrectly()
+        {
+            using var content = new StringContent(okBody);
+            using var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = content,
+            };
+
+            HttpRequestMessage sentRequestMessage = null;
+
+            var httpMessageHandler = new Mock<HttpMessageHandler>();
+            httpMessageHandler
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>())
+               .Callback((HttpRequestMessage httpRequestMessage, CancellationToken cancellationToken) =>
+               {
+                   sentRequestMessage = httpRequestMessage;
+               })
+               .ReturnsAsync(response);
+
+            var httpClient = new HttpClient(httpMessageHandler.Object);
+            var abuseIpDbClient = new AbuseIPDBClient(httpClient, "apiKey", new Uri("https://api.abuseipdb.com/api/v2/"));
+            (ReportUpdate data, RateLimit rateLimit) = await abuseIpDbClient.ReportAsync("127.0.0.1", "Comment with spaces", new[] { Category.BadWebBot }, CancellationToken.None);
+
+            sentRequestMessage.Should().NotBeNull();
+            sentRequestMessage.RequestUri.AbsoluteUri.Should().Be("https://api.abuseipdb.com/api/v2/report?ip=127.0.0.1&categories=19&comment=Comment%20with%20spaces");
+        }
+
+        [TestMethod]
+        public async Task ResponseIsDeserializedAsExpected()
+        {
+            using var content = new StringContent(okBody);
+            using var response = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = content,
+            };
+
+            var httpMessageHandler = new Mock<HttpMessageHandler>();
+            httpMessageHandler
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>())
+               .ReturnsAsync(response);
+
+            var httpClient = new HttpClient(httpMessageHandler.Object);
+            var abuseIpDbClient = new AbuseIPDBClient(httpClient, "apiKey", new Uri("https://api.abuseipdb.com/api/v2/"));
+            (ReportUpdate data, RateLimit rateLimit) = await abuseIpDbClient.ReportAsync("127.0.0.1", "Comment with spaces", new[] { Category.BadWebBot }, CancellationToken.None);
+
+            // check the result
+            data.IpAddress.Should().Be("127.0.0.1");
+            data.AbuseConfidenceScore.Should().Be(52);
+        }
+    }
+}

--- a/src/Kenc.AbuseIPDB/ApiReplies/ListApiReply.cs
+++ b/src/Kenc.AbuseIPDB/ApiReplies/ListApiReply.cs
@@ -1,13 +1,16 @@
 ﻿namespace Kenc.AbuseIPDB.ApiReplies
 {
     using System.Collections.Generic;
+    using System.Text.Json.Serialization;
 
     public class ListApiReply<T, M> : IApiReply<IReadOnlyList<T>, M>
         where T : IApiEntity
         where M : IApiMetadata
     {
+        [JsonPropertyName("meta")]
         public M Meta { get; set; }
 
+        [JsonPropertyName("data")]
         public IReadOnlyList<T> Data { get; set; }
     }
 }

--- a/src/Kenc.AbuseIPDB/Entities/Check.cs
+++ b/src/Kenc.AbuseIPDB/Entities/Check.cs
@@ -27,6 +27,9 @@
         [JsonPropertyName("countryName")]
         public string CountryName { get; set; }
 
+        [JsonPropertyName("domain")]
+        public string Domain { get; set; }
+
         [JsonPropertyName("usageType")]
         public string UsageType { get; set; }
 

--- a/src/kenc.abuseipdb.sln
+++ b/src/kenc.abuseipdb.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kenc.AbuseIPDB", "Kenc.Abus
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kenc.AbuseIPDB.Tests", "Kenc.AbuseIPDB.Tests\Kenc.AbuseIPDB.Tests.csproj", "{7AF8E306-EE9F-4940-8B81-C72FF8EE8919}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kenc.AbuseIPDB.Cache", "Kenc.AbuseIPDB.Cache\Kenc.AbuseIPDB.Cache.csproj", "{1365E194-D28C-47A5-B453-3B1F59A31F1E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{7AF8E306-EE9F-4940-8B81-C72FF8EE8919}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7AF8E306-EE9F-4940-8B81-C72FF8EE8919}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7AF8E306-EE9F-4940-8B81-C72FF8EE8919}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1365E194-D28C-47A5-B453-3B1F59A31F1E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1365E194-D28C-47A5-B453-3B1F59A31F1E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1365E194-D28C-47A5-B453-3B1F59A31F1E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1365E194-D28C-47A5-B453-3B1F59A31F1E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
AbuseIPDB is an excellent service to add a caching layer in front.
With the free tier you have 1,000 checks per day - checking the same IP over and over will quickly exhaust these.

- #8  Add cached client utilizing a memory cache based on LazyCache.
The cached client is added in it's own package.

- #9 Add Readme.md to packages
nuget.org supports [Readme's in nuget packages](https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/).
Go ahead and bundle the readme with both packages.

- #10 Extend unittest coverage
Add more extensive unit tests.