### PR TITLE
Remove leftover package reference of LazyCache

### DIFF
--- a/src/Kenc.AbuseIPDB/AbuseIPDBEndpoints.cs
+++ b/src/Kenc.AbuseIPDB/AbuseIPDBEndpoints.cs
@@ -4,6 +4,6 @@
 
     public class AbuseIpDbEndpoints
     {
-        public static readonly Uri V2Endpoint = new Uri("https://api.abuseipdb.com/api/v2/");
+        public static readonly Uri V2Endpoint = new("https://api.abuseipdb.com/api/v2/");
     }
 }

--- a/src/Kenc.AbuseIPDB/Kenc.AbuseIPDB.csproj
+++ b/src/Kenc.AbuseIPDB/Kenc.AbuseIPDB.csproj
@@ -28,7 +28,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LazyCache" Version="2.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />


### PR DESCRIPTION
The first iteration of adding the cache, it was added directly in the library.
As a result, a reference to LazyCache was added.
This unfortunately wasn't removed, before completing the PR.

Use new() syntax in AbuseIPDBEndpoints