### PR TITLE
Prepare for 1.0 release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,4 @@
 # pipeline for building Kenc.ACMELib.
-
 trigger:
 - main
 
@@ -9,7 +8,7 @@ pool:
 variables:
    major: 1
    minor: 0
-   beta: true
+   beta: false
    solution: '**/*.sln'
    buildConfiguration: 'Release'
 
@@ -29,7 +28,7 @@ stages:
       - bash: |
            echo "##vso[build.updatebuildnumber]$(major).$(minor).$(patch)"
            echo "##vso[task.setvariable variable=assemblyVersionStr]$(major).$(minor).$(patch)"
-        condition: ne(variables['beta'], true)
+        condition: ne(variables['beta'], false)
         name: SetMasterBuildName
       - bash: |
            echo "##vso[build.updatebuildnumber]$(major).$(minor).$(patch)-beta"
@@ -59,11 +58,15 @@ stages:
 - stage: Build_Steps
   displayName: Build_Steps
   condition: always()
-  jobs:  
+  jobs:
   - job: Build_Steps
     timeoutInMinutes: 10 # how long to run the job before automatically cancelling
     displayName: Build_Steps
     steps:
+    - task: UseDotNet@2
+      inputs:
+        packageType: 'sdk'
+        useGlobalJson: true
     - script: dotnet restore $(solution)
       name: dotnet_restore
     - script: "dotnet build $(solution) -c $(BuildConfiguration) /p:version=$(Build.BuildNumber) /p:assemblyversion=$(assemblyVersionStr)"

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.100",
+    "rollForward": "latestFeature"
+  }
+}

--- a/src/Kenc.AbuseIPDB.Cache/Kenc.AbuseIPDB.Cache.csproj
+++ b/src/Kenc.AbuseIPDB.Cache/Kenc.AbuseIPDB.Cache.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
+    <LangVersion>10.0</LangVersion>
     <TargetFramework>netstandard2.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LazyCache" Version="2.1.3" />
+    <PackageReference Include="LazyCache" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="Docs\README.md" Pack="true" PackagePath="\"/>
+    <None Include="Docs\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kenc.AbuseIPDB.Tests/Kenc.AbuseIPDB.Tests.csproj
+++ b/src/Kenc.AbuseIPDB.Tests/Kenc.AbuseIPDB.Tests.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.4" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kenc.AbuseIPDB/AbuseIPDBClient.cs
+++ b/src/Kenc.AbuseIPDB/AbuseIPDBClient.cs
@@ -9,6 +9,7 @@
     using System.Reflection;
     using System.Runtime.InteropServices;
     using System.Text.Json;
+    using System.Text.Json.Serialization;
     using System.Threading;
     using System.Threading.Tasks;
     using System.Web;
@@ -27,7 +28,7 @@
         private readonly HttpClient httpClient;
         private static readonly JsonSerializerOptions jsonSerializerOptions = new()
         {
-            IgnoreNullValues = true
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
         };
 
         /// <summary>

--- a/src/Kenc.AbuseIPDB/Kenc.AbuseIPDB.csproj
+++ b/src/Kenc.AbuseIPDB/Kenc.AbuseIPDB.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
+    <LangVersion>10.0</LangVersion>
     <TargetFramework>netstandard2.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
@@ -31,15 +31,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
-    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+    <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="Docs\README.md" Pack="true" PackagePath="\"/>
+    <None Include="Docs\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgrade to latest dotnet toolchain version (6.0.100) using global.json
Update azure-pipelines.yml to auto-install dotnet version mentioned in global.json
Update azure-pipelines.yml to fix issue with selecting version when beta is false.
Upgrade testproject to .net 6.0