### PR TITLE
Update nuget packages and compiler version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "7.0.101",
+      "version": "8.0.403",
       "rollForward": "latestFeature",
       "allowPrerelease": false
     }

--- a/src/Kenc.AbuseIPDB.Cache/Kenc.AbuseIPDB.Cache.csproj
+++ b/src/Kenc.AbuseIPDB.Cache/Kenc.AbuseIPDB.Cache.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LazyCache" Version="2.4.0" />
+    <PackageReference Include="LazyCache" Version="[2.4.0,3.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kenc.AbuseIPDB.Tests/Kenc.AbuseIPDB.Tests.csproj
+++ b/src/Kenc.AbuseIPDB.Tests/Kenc.AbuseIPDB.Tests.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kenc.AbuseIPDB.Tests/Kenc.AbuseIPDB.Tests.csproj
+++ b/src/Kenc.AbuseIPDB.Tests/Kenc.AbuseIPDB.Tests.csproj
@@ -1,21 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8</TargetFramework>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="FluentAssertions" Version="6.12.1" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+		<PackageReference Include="Moq" Version="4.18.4" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Kenc.AbuseIPDB.Cache\Kenc.AbuseIPDB.Cache.csproj" />
-    <ProjectReference Include="..\Kenc.AbuseIPDB\Kenc.AbuseIPDB.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Kenc.AbuseIPDB.Cache\Kenc.AbuseIPDB.Cache.csproj" />
+		<ProjectReference Include="..\Kenc.AbuseIPDB\Kenc.AbuseIPDB.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Kenc.AbuseIPDB/Kenc.AbuseIPDB.csproj
+++ b/src/Kenc.AbuseIPDB/Kenc.AbuseIPDB.csproj
@@ -15,7 +15,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <PackageTags>AbuseIPDB</PackageTags>
-    <Copyright>2023 Ken Christensen</Copyright>
+    <Copyright>2024 Ken Christensen</Copyright>
     <Description>.net core standard library for interacting with the AbuseIPDB API v2.</Description>
 
     <!-- Debug symbols package properties-->
@@ -30,11 +30,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[8.0.0,9.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="[8.0.1,9.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2,9.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="[8.0.0,9.0.0)" />
+    <PackageReference Include="System.Net.Http.Json" Version="[8.0.1,9.0.0)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated referenced nuget packages to their latest versions and introduce range selectors.
Additionally, update the target compiler version to the latest 8.x tool chain